### PR TITLE
trailpack.js -> main.js

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ to a [Hapi Server](http://hapijs.com/api#server).
 Load in your trailpack config.
 
 ```js
-// config/trailpack.js
+// config/main.js
 module.exports = {
   // ...
   packs: [


### PR DESCRIPTION
I was following the documentation with a freshly generated install of Trails.  It seems like the file referenced as trailpack.js in the docs is actually main.js.
